### PR TITLE
Add support for different backends needing different message format

### DIFF
--- a/PoshBot.XKCD/PoshBot.XKCD.psm1
+++ b/PoshBot.XKCD/PoshBot.XKCD.psm1
@@ -69,7 +69,12 @@ function Get-XKCD {
         $item | Foreach-Object {
             $comic = Invoke-RestMethod "https://xkcd.com/$_/info.0.json" -ErrorAction SilentlyContinue
             if ($comic) {
-                $comic.img
+                if ($global:PoshbotContext.BackendType -in @('TeamsBackend')) {
+                    "![img]($($comic.img))"
+                }
+                else {
+                    $comic.img
+                }
                 if($AltText){
                     '>' + $comic.alt
                 }


### PR DESCRIPTION
## Description
Return markdown for Teams but the normal link format for other backends due to Teams not expanding image links automatically.

## Related Issue
https://github.com/poshbotio/PoshBot/issues/104

## How Has This Been Tested?
Tested locally using Teams, there should be no change to the behaviour for Slack and other backends.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
